### PR TITLE
Upgraded Jenkins and base OS versions, added support to Flex shapes

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -1,6 +1,7 @@
 ############################################
 # Datasource
 ############################################
+
 # Gets a list of Availability Domains
 data "oci_identity_availability_domains" "ad" {
   compartment_id = var.tenancy_ocid
@@ -23,10 +24,37 @@ data "oci_core_vnic" "bastion_VNIC1" {
   vnic_id = data.oci_core_vnic_attachments.bastion_VNIC1_attach.vnic_attachments.0.vnic_id
 }
 
-data "oci_core_images" "InstanceImageOCID" {
+data "oci_core_images" "master_image" {
   compartment_id           = var.compartment_ocid
   operating_system         = var.instance_os
   operating_system_version = var.linux_os_version
+  shape                    = var.master_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_core_images" "agent_image" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.agent_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_core_images" "bastion_image" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.bastion_shape
 
   filter {
     name   = "display_name"

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -11,7 +11,7 @@ resource "oci_load_balancer" "JenkinsLB" {
   ]
 
   display_name = "JenkinsLB"
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 resource "oci_load_balancer_backend_set" "JenkinsLBBes" {
@@ -86,7 +86,7 @@ resource "oci_load_balancer_listener" "JenkinsLBLsnr_SSL" {
   load_balancer_id         = oci_load_balancer.JenkinsLB.id
   name                     = "https"
   default_backend_set_name = oci_load_balancer_backend_set.JenkinsLBBes.name
-  port                     = 443
+  port                     = var.lb_https_port
   protocol                 = "HTTP"
 
   ssl_configuration {

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,44 @@
+locals {
+
+  # Network Locals #
+
+  // contains bastion, LB, and anything internet-facing
+  dmz_tier_prefix = cidrsubnet(var.vcn_cidr, 2, 0)
+
+  // contains private subnets with app logic
+  app_tier_prefix = cidrsubnet(var.vcn_cidr, 2, 1)
+
+  lb_subnet_prefix      = cidrsubnet(local.dmz_tier_prefix, 2, 0)
+  bastion_subnet_prefix = cidrsubnet(local.dmz_tier_prefix, 2, 1)
+  master_subnet_prefix  = cidrsubnet(local.app_tier_prefix, 2, 0)
+  agent_subnet_prefix   = cidrsubnet(local.app_tier_prefix, 2, 1)
+
+
+  # Compute Locals #
+
+  # ------------------------------------------------------------------------------
+  # Bastion Host Locals
+  # ------------------------------------------------------------------------------
+  bastion_shape             = var.bastion_shape
+  bastion_flex_shape_ocpus  = var.bastion_flex_shape_ocpus
+  bastion_flex_shape_memory = var.bastion_flex_shape_memory
+  bastion_is_flex_shape     = length(regexall("Flex", local.bastion_shape)) > 0 ? [1] : []
+
+
+  # ------------------------------------------------------------------------------
+  # Master Host Locals
+  # ------------------------------------------------------------------------------
+  master_shape             = var.master_shape
+  master_flex_shape_ocpus  = var.master_flex_shape_ocpus
+  master_flex_shape_memory = var.master_flex_shape_memory
+
+
+  # ------------------------------------------------------------------------------
+  # Agent Host Locals
+  # ------------------------------------------------------------------------------
+  agent_shape             = var.agent_shape
+  agent_flex_shape_ocpus  = var.agent_flex_shape_ocpus
+  agent_flex_shape_memory = var.agent_flex_shape_memory
+
+
+}

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,16 @@ resource "oci_core_instance" "JenkinsBastion" {
   availability_domain = var.availablity_domain_name
   compartment_id      = var.compartment_ocid
   display_name        = var.bastion_display_name
-  shape               = var.bastion_shape
+  shape               = local.bastion_shape
+
+  dynamic "shape_config" {
+    for_each = local.bastion_is_flex_shape
+    content {
+      ocpus         = local.bastion_flex_shape_ocpus
+      memory_in_gbs = local.bastion_flex_shape_memory
+    }
+  }
+
 
   create_vnic_details {
     subnet_id        = oci_core_subnet.JenkinsBastion.id
@@ -17,36 +26,39 @@ resource "oci_core_instance" "JenkinsBastion" {
   }
 
   source_details {
-#    source_id   = data.oci_core_images.InstanceImageOCID.images[0].id
-    source_id   = lookup(data.oci_core_images.InstanceImageOCID.images[0], "id")
+    source_id   = lookup(data.oci_core_images.bastion_image.images[0], "id")
     source_type = "image"
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 # ------------------------------------------------------------------------------
 # DEPLOY THE JENKINS CLUSTER
 # ------------------------------------------------------------------------------
 module "jenkins" {
-  source 	            = "github.com/oracle-quickstart/oci-jenkins"
-  compartment_ocid    = var.compartment_ocid
-  jenkins_version     = var.jenkins_version
-  jenkins_password    = var.jenkins_password
-  master_ad           = data.template_file.ad_names[0].rendered
-  master_subnet_id    = oci_core_subnet.JenkinsMasterSubnetAD.id
-  master_image_id     = lookup(data.oci_core_images.InstanceImageOCID.images[0], "id")
-  master_shape        = var.master_shape
-  plugins             = split(",", var.plugins)
-  agent_count         = var.agent_count
-  agent_ads           = data.template_file.ad_names.*.rendered
-  agent_subnet_ids    = split(",", join(",", oci_core_subnet.JenkinsAgentSubnetAD.*.id))
-  agent_image_id      = data.oci_core_images.InstanceImageOCID.images[0].id
-  agent_shape         = var.agent_shape
-  ssh_authorized_keys = tls_private_key.public_private_key_pair.public_key_openssh
-  ssh_private_key     = tls_private_key.public_private_key_pair.private_key_pem
-  bastion_host        = oci_core_instance.JenkinsBastion.public_ip
-  bastion_user        = var.bastion_user
-  bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
-  http_port           = var.http_port
+  source                   = "github.com/oracle-quickstart/oci-jenkins"  
+  compartment_ocid         = var.compartment_ocid
+  jenkins_version          = var.jenkins_version
+  jenkins_password         = var.jenkins_password
+  master_ad                = data.template_file.ad_names[0].rendered
+  master_subnet_id         = oci_core_subnet.JenkinsMasterSubnetAD.id
+  master_image_id          = lookup(data.oci_core_images.master_image.images[0], "id")
+  master_shape             = var.master_shape
+  master_flex_shape_ocpus  = var.master_flex_shape_ocpus
+  master_flex_shape_memory = var.master_flex_shape_memory
+  plugins                  = split(",", var.plugins)
+  agent_count              = var.agent_count
+  agent_ads                = data.template_file.ad_names.*.rendered
+  agent_subnet_ids         = split(",", join(",", oci_core_subnet.JenkinsAgentSubnetAD.*.id))
+  agent_image_id           = data.oci_core_images.agent_image.images[0].id
+  agent_shape              = var.agent_shape
+  agent_flex_shape_ocpus   = var.agent_flex_shape_ocpus
+  agent_flex_shape_memory  = var.agent_flex_shape_memory
+  ssh_authorized_keys      = tls_private_key.public_private_key_pair.public_key_openssh
+  ssh_private_key          = tls_private_key.public_private_key_pair.private_key_pem
+  bastion_host             = oci_core_instance.JenkinsBastion.public_ip
+  bastion_user             = var.bastion_user
+  bastion_private_key      = tls_private_key.public_private_key_pair.private_key_pem
+  http_port                = var.http_port
 }
 

--- a/network.tf
+++ b/network.tf
@@ -6,7 +6,7 @@ resource "oci_core_virtual_network" "JenkinsVCN" {
   display_name   = "JenkinsVCN"
   cidr_block     = var.vcn_cidr
   dns_label      = "JenkinsVCN"
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags   = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
@@ -16,7 +16,7 @@ resource "oci_core_internet_gateway" "JenkinsIG" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_virtual_network.JenkinsVCN.id
   display_name   = "JenkinsIG"
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags   = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
@@ -26,7 +26,7 @@ resource "oci_core_nat_gateway" "JenkinsNG" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_virtual_network.JenkinsVCN.id
   display_name   = "JenkinsNG"
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags   = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
@@ -53,7 +53,7 @@ resource "oci_core_route_table" "private" {
     destination_type  = "CIDR_BLOCK"
     network_entity_id = oci_core_nat_gateway.JenkinsNG.id
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
@@ -96,7 +96,7 @@ resource "oci_core_security_list" "JenkinsPrivate" {
     protocol = "6"
     source   = "0.0.0.0/0"
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 resource "oci_core_security_list" "JenkinsBastion" {
@@ -118,7 +118,7 @@ resource "oci_core_security_list" "JenkinsBastion" {
     protocol = "6"
     source   = "0.0.0.0/0"
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 resource "oci_core_security_list" "JenkinsNat" {
@@ -135,7 +135,7 @@ resource "oci_core_security_list" "JenkinsNat" {
     protocol = "6"
     source   = var.vcn_cidr
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 resource "oci_core_security_list" "JenkinsLB" {
@@ -166,72 +166,72 @@ resource "oci_core_security_list" "JenkinsLB" {
       max = 443
     }
   }
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  defined_tags = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
 # Create Master Subnet
 ############################################
 resource "oci_core_subnet" "JenkinsMasterSubnetAD" {
-#  availability_domain = data.template_file.ad_names[0].rendered
-  cidr_block          = cidrsubnet(local.master_subnet_prefix, 4, 0)
-#  display_name        = "${var.label_prefix}JenkinsMasterSubnetAD"
-   display_name        = "JenkinsMasterSubnet"
-  dns_label           = "masterad"
-  security_list_ids   = [oci_core_security_list.JenkinsPrivate.id]
-  compartment_id      = var.compartment_ocid
-  vcn_id              = oci_core_virtual_network.JenkinsVCN.id
-  route_table_id      = oci_core_route_table.private.id
-  dhcp_options_id     = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  #  availability_domain = data.template_file.ad_names[0].rendered
+  cidr_block = cidrsubnet(local.master_subnet_prefix, 4, 0)
+  #  display_name        = "${var.label_prefix}JenkinsMasterSubnetAD"
+  display_name      = "JenkinsMasterSubnet"
+  dns_label         = "masterad"
+  security_list_ids = [oci_core_security_list.JenkinsPrivate.id]
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.JenkinsVCN.id
+  route_table_id    = oci_core_route_table.private.id
+  dhcp_options_id   = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
+  defined_tags      = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
 # Create agent Subnet
 ############################################
 resource "oci_core_subnet" "JenkinsAgentSubnetAD" {
-  count               = length(data.template_file.ad_names.*.rendered)
-#  availability_domain = data.template_file.ad_names[count.index].rendered
-  cidr_block          = cidrsubnet(local.agent_subnet_prefix, 4, count.index)
-  display_name        = "${var.label_prefix}JenkinsAgentSubnet${count.index + 1}"
-  dns_label           = "agentad${count.index + 1}"
-  security_list_ids   = [oci_core_security_list.JenkinsPrivate.id]
-  compartment_id      = var.compartment_ocid
-  vcn_id              = oci_core_virtual_network.JenkinsVCN.id
-  route_table_id      = oci_core_route_table.private.id
-  dhcp_options_id     = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  count = length(data.template_file.ad_names.*.rendered)
+  #  availability_domain = data.template_file.ad_names[count.index].rendered
+  cidr_block        = cidrsubnet(local.agent_subnet_prefix, 4, count.index)
+  display_name      = "${var.label_prefix}JenkinsAgentSubnet${count.index + 1}"
+  dns_label         = "agentad${count.index + 1}"
+  security_list_ids = [oci_core_security_list.JenkinsPrivate.id]
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.JenkinsVCN.id
+  route_table_id    = oci_core_route_table.private.id
+  dhcp_options_id   = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
+  defined_tags      = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
 # Create Bastion Subnet
 ############################################
 resource "oci_core_subnet" "JenkinsBastion" {
-#  availability_domain = data.template_file.ad_names[var.bastion_ad_index].rendered
-  compartment_id      = var.compartment_ocid
-  display_name        = "JenkinsBastion"
-  cidr_block          = cidrsubnet(local.bastion_subnet_prefix, 4, 0)
-  security_list_ids   = [oci_core_security_list.JenkinsBastion.id]
-  vcn_id              = oci_core_virtual_network.JenkinsVCN.id
-  route_table_id      = oci_core_route_table.public.id
-  dhcp_options_id     = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  #  availability_domain = data.template_file.ad_names[var.bastion_ad_index].rendered
+  compartment_id    = var.compartment_ocid
+  display_name      = "JenkinsBastion"
+  cidr_block        = cidrsubnet(local.bastion_subnet_prefix, 4, 0)
+  security_list_ids = [oci_core_security_list.JenkinsBastion.id]
+  vcn_id            = oci_core_virtual_network.JenkinsVCN.id
+  route_table_id    = oci_core_route_table.public.id
+  dhcp_options_id   = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
+  defined_tags      = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 ############################################
 # Create LoadBalancer Subnet
 ############################################
 resource "oci_core_subnet" "JenkinsLBSubnet1" {
-#  availability_domain = data.template_file.ad_names[0].rendered
-  cidr_block          = cidrsubnet(local.lb_subnet_prefix, 4, 0)
-  display_name        = "JenkinsLBSubnet1"
-  dns_label           = "subnet1"
-  security_list_ids   = [oci_core_security_list.JenkinsLB.id]
-  compartment_id      = var.compartment_ocid
-  vcn_id              = oci_core_virtual_network.JenkinsVCN.id
-  route_table_id      = oci_core_route_table.public.id
-  dhcp_options_id     = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
-  defined_tags = {"${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
+  #  availability_domain = data.template_file.ad_names[0].rendered
+  cidr_block        = cidrsubnet(local.lb_subnet_prefix, 4, 0)
+  display_name      = "JenkinsLBSubnet1"
+  dns_label         = "subnet1"
+  security_list_ids = [oci_core_security_list.JenkinsLB.id]
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.JenkinsVCN.id
+  route_table_id    = oci_core_route_table.public.id
+  dhcp_options_id   = oci_core_virtual_network.JenkinsVCN.default_dhcp_options_id
+  defined_tags      = { "${oci_identity_tag_namespace.ArchitectureCenterTagNamespace.name}.${oci_identity_tag.ArchitectureCenterTag.name}" = var.release }
 }
 
 #resource "oci_core_subnet" "JenkinsLBSubnet2" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,9 +6,14 @@ output "agent_private_ips" {
   value = module.jenkins.agent_private_ips
 }
 
-output "jenkins_login_url" {
+output "jenkins_http_login_url" {
   value = "http://${oci_load_balancer.JenkinsLB.ip_addresses[0]}:${var.lb_http_port}/"
 }
+
+output "jenkins_https_login_url" {
+  value = "https://${oci_load_balancer.JenkinsLB.ip_addresses[0]}:${var.lb_https_port}/"
+}
+
 
 output "generated_ssh_private_key" {
   value = tls_private_key.public_private_key_pair.private_key_pem

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,6 @@
+## This file declare Provider block and variables required to run the template using Terraform CLI with standard user based authentication.
+## Remove this file from your OCI ORM Stack as ORM will pick up these variables from the authenticated user running the ORM Stack.
+
 ############################################
 # Provider
 ############################################
@@ -9,3 +12,11 @@ provider "oci" {
   region           = var.region
 }
 
+variable "user_ocid" {
+}
+
+variable "fingerprint" {
+}
+
+variable "private_key_path" {
+}

--- a/schema.yaml
+++ b/schema.yaml
@@ -4,7 +4,7 @@
 title: "Jenkins in master-agent mode"
 description: "Host Jenkins on Oracle Cloud Infrastructure to centralize your build automation and scale your deployment as the needs of your software projects grow."
 stackDescription: "Jenkins in master-agent mode"
-informationalText: "To connect to the Jenkins UI, copy jenkins_login_url and paste it to your web browser."
+informationalText: "To connect to the Jenkins UI, copy jenkins_http_login_url or jenkins_https_login_url and paste it to your web browser."
 schemaVersion: 1.1.0
 version: "20201028"
 locale: "en"
@@ -30,6 +30,7 @@ variableGroups:
   - vcn_cidr
   - label_prefix
   - lb_http_port
+  - lb_https_port
   - http_port
   - jnlp_port
   - jenkins_version
@@ -38,8 +39,14 @@ variableGroups:
   - linux_os_version
   - bastion_display_name
   - bastion_shape
+  - bastion_flex_shape_ocpus
+  - bastion_flex_shape_memory
   - master_shape
+  - master_flex_shape_ocpus
+  - master_flex_shape_memory
   - agent_shape
+  - agent_flex_shape_ocpus
+  - agent_flex_shape_memory
   - bastion_user
   - listener_ca_certificate
   - listener_private_key
@@ -115,9 +122,19 @@ variables:
     required: false
 
   lb_http_port:
-    title: "Load Balanacer HTTP Port"
+    title: "Load Balancer HTTP Port"
     description: "Load Balancer HTTP Port"
     default: 80
+    minimum: 1
+    maximum: 65535
+    multipleOf: 1
+    type: number
+    required: false
+
+  lb_https_port:
+    title: "Load Balancer HTTPS Port"
+    description: "Load Balancer HTTPS Port"
+    default: 443
     minimum: 1
     maximum: 65535
     multipleOf: 1
@@ -147,10 +164,10 @@ variables:
   jenkins_version:
     title: "Jenkins version"
     description: "Jenkins software version"
-    default: "2.249.1"
+    default: "2.277.4"
     type: enum
     enum: 
-      - "2.249.1"
+      - "2.277.4"
     required: false
 
   agent_count:
@@ -199,6 +216,46 @@ variables:
     dependsOn:
       compartmentId: ${compartment_ocid}
 
+  bastion_flex_shape_ocpus:
+    visible:
+      or:
+        - eq:
+          - bastion_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - bastion_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - bastion_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 1
+    title: Bastion Server Flex Shape OCPUs
+    minimum: 1
+    maximum: 64
+    required: false
+    description: Maximum of 64 OCPUs
+    
+  bastion_flex_shape_memory:
+    visible:
+      or:
+        - eq:
+          - bastion_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - bastion_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - bastion_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 6
+    title: Bastion Server Flex Shape Memory 
+    minimum: 1
+    maximum: 1024
+    required: false
+    description: Minimum 1GB or 6GB. Maximum of 64GB per OCPU up to 1024GB
+
   master_shape:
     type: oci:core:instanceshape:name
     title: "Jenkins Master Server Shape"
@@ -208,6 +265,47 @@ variables:
     dependsOn:
       compartmentId: ${compartment_ocid}
 
+  master_flex_shape_ocpus:
+    visible:
+      or:
+        - eq:
+          - master_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - master_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - master_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 1
+    title: Jenkins Master Server Flex Shape OCPUs
+    minimum: 1
+    maximum: 64
+    required: false
+    description: Maximum of 64 OCPUs
+
+    
+  master_flex_shape_memory:
+    visible:
+      or:
+        - eq:
+          - master_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - master_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - master_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 6
+    title: Jenkins Master Server Flex Shape Memory 
+    minimum: 1
+    maximum: 1024
+    required: false
+    description: Minimum 1GB or 6GB. Maximum of 64GB per OCPU up to 1024GB
+
   agent_shape:
     type: oci:core:instanceshape:name
     title: "Jenkins Agent Server Shape"
@@ -216,6 +314,48 @@ variables:
     required: false
     dependsOn:
       compartmentId: ${compartment_ocid}
+
+  agent_flex_shape_ocpus:
+    visible:
+      or:
+        - eq:
+          - agent_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - agent_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - agent_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 1
+    title: Jenkins Agent Server Flex Shape OCPUs
+    minimum: 1
+    maximum: 64
+    required: false
+    description: Maximum of 64 OCPUs
+
+    
+  agent_flex_shape_memory:
+    visible:
+      or:
+        - eq:
+          - agent_shape
+          - "VM.Standard.E3.Flex"
+        - eq:
+          - agent_shape
+          - "VM.Standard.E4.Flex"
+        - eq:
+          - agent_shape
+          - "VM.Standard.A1.Flex"
+    type: integer
+    default: 6
+    title: Jenkins Agent Server Flex Shape Memory 
+    minimum: 1
+    maximum: 1024
+    required: false
+    description: Minimum 1GB or 6GB. Maximum of 64GB per OCPU up to 1024GB
+
 
   bastion_user:
     type: string
@@ -257,12 +397,18 @@ outputs:
     type: copyableString
     visible: true
 
-  jenkins_login_url:
-    title: "Jenkins Login URL"
-    displayText: "Jenkins Login URL"
+  jenkins_http_login_url:
+    title: "Jenkins HTTP Login URL"
+    displayText: "Jenkins HTTP Login URL"
     type: string
     visible: true
-  
+
+  jenkins_https_login_url:
+    title: "Jenkins HTTPS Login URL"
+    displayText: "Jenkins HTTPS Login URL"
+    type: string
+    visible: true
+    
   generated_ssh_private_key:
     title: "Generated SSH Private Key"
     displayText: "Generated SSH Private Key"

--- a/tags.tf
+++ b/tags.tf
@@ -2,27 +2,27 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 resource "oci_identity_tag_namespace" "ArchitectureCenterTagNamespace" {
-    compartment_id = var.compartment_ocid
-    description = "ArchitectureCenterTagNamespace"
-    name = "ArchitectureCenter\\jenkins-master-agent-mode"
+  compartment_id = var.compartment_ocid
+  description    = "ArchitectureCenterTagNamespace"
+  name           = "ArchitectureCenter\\jenkins-master-agent-mode"
 
-    provisioner "local-exec" {
-       command = "sleep 10"
-    }
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
 
 }
 
 resource "oci_identity_tag" "ArchitectureCenterTag" {
-    description = "ArchitectureCenterTag"
-    name = "release"
-    tag_namespace_id = oci_identity_tag_namespace.ArchitectureCenterTagNamespace.id
+  description      = "ArchitectureCenterTag"
+  name             = "release"
+  tag_namespace_id = oci_identity_tag_namespace.ArchitectureCenterTagNamespace.id
 
-    validator {
-        validator_type = "ENUM"
-        values         = ["release", "1.1"]
-    }
+  validator {
+    validator_type = "ENUM"
+    values         = ["release", "1.1"]
+  }
 
-    provisioner "local-exec" {
-       command = "sleep 20"
-    }
+  provisioner "local-exec" {
+    command = "sleep 20"
+  }
 }

--- a/tls.tf
+++ b/tls.tf
@@ -1,3 +1,3 @@
 resource "tls_private_key" "public_private_key_pair" {
-  algorithm   = "RSA"
+  algorithm = "RSA"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,4 @@
 variable "tenancy_ocid" {}
-variable "user_ocid" {}
-variable "fingerprint" {}
-variable "private_key_path" {}
 variable "region" {}
 variable "compartment_ocid" {}
 variable "availablity_domain_name" {}
@@ -15,19 +12,6 @@ variable "vcn_cidr" {
   default = "10.0.0.0/16"
 }
 
-locals {
-  // contains bastion, LB, and anything internet-facing
-  dmz_tier_prefix = cidrsubnet(var.vcn_cidr, 2, 0)
-
-  // contains private subnets with app logic
-  app_tier_prefix = cidrsubnet(var.vcn_cidr, 2, 1)
-
-  lb_subnet_prefix      = cidrsubnet(local.dmz_tier_prefix, 2, 0)
-  bastion_subnet_prefix = cidrsubnet(local.dmz_tier_prefix, 2, 1)
-  master_subnet_prefix  = cidrsubnet(local.app_tier_prefix, 2, 0)
-  agent_subnet_prefix   = cidrsubnet(local.app_tier_prefix, 2, 1)
-}
-
 variable "label_prefix" {
   default = ""
 }
@@ -38,6 +22,10 @@ variable "http_port" {
 
 variable "lb_http_port" {
   default = 80
+}
+
+variable "lb_https_port" {
+  default = 443
 }
 
 variable "jnlp_port" {
@@ -56,8 +44,7 @@ variable "plugins" {
 }
 
 variable "jenkins_version" {
-#  default = "2.138.2"
-  default = "2.249.1"
+  default = "2.277.4"
 }
 
 variable "jenkins_password" {
@@ -75,12 +62,36 @@ variable "bastion_shape" {
   default = "VM.Standard2.1"
 }
 
+variable "bastion_flex_shape_ocpus" {
+  default = ""
+}
+
+variable "bastion_flex_shape_memory" {
+  default = ""
+}
+
 variable "master_shape" {
   default = "VM.Standard2.4"
 }
 
+variable "master_flex_shape_ocpus" {
+  default = ""
+}
+
+variable "master_flex_shape_memory" {
+  default = ""
+}
+
 variable "agent_shape" {
   default = "VM.Standard2.4"
+}
+
+variable "agent_flex_shape_ocpus" {
+  default = ""
+}
+
+variable "agent_flex_shape_memory" {
+  default = ""
 }
 
 variable "bastion_user" {
@@ -110,6 +121,6 @@ variable "instance_os" {
 
 variable "linux_os_version" {
   description = "Operating system version for all Linux instances"
-  default     = "7.8"
+  default     = "7.9"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,22 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
+  required_providers {
+    oci = {
+      source  = "hashicorp/oci"
+      version = ">= 4.24"
+    }
+
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 2.0.1"
+    }
+
+  }
 }
+


### PR DESCRIPTION
* Upgraded Jenkins to latest available version
* Upgraded template to support OCI Compute Flex shapes
* Fixed data source to fetch images compatible with shapes - required data source for each instance/image
* Upgraded base OS from OL 7.8 to OL.79 which required changes to the installation script
   * Removed `xmlstarlet`package dependencies from script
   * Added some logic on waitForJenkins function when it fails to connect to the server
* Formatted code
* Refactored code
  * added locals to its own file
  * added CLI specific Provider variables into provider.tf
  * added versions.tf containing provider minimum version support